### PR TITLE
Add Steins;Place overlay

### DIFF
--- a/omoriplace.json
+++ b/omoriplace.json
@@ -60,6 +60,12 @@
             "y": 1000
         }
     ],
+    "whitelist": [
+        {
+            "name": "Steins;Place",
+            "url": "https://r-steins-place.pages.dev/overlay.json"
+        }
+    ],
     "blacklist": [
         {
             "name": "r/omori",

--- a/omoriplace.json
+++ b/omoriplace.json
@@ -1,7 +1,6 @@
 {
     "faction": "/r/omori",
-    "contact": "omocord",
-    "notifications": "?????",
+    "contact": "https://discord.gg/omori",
     "templates": [
         {
             "name": "OMORI Picnic Table",


### PR DESCRIPTION
With this change, Steins;Place's overlay will automagically show up in your overlay.

We have your overlay on our whitelist (https://r-steins-place.pages.dev/overlay.json), so your overlay shows up for us too. Like so:

![both overlays working](https://github.com/Ayaya-Xiao/omoriplace2023bis/assets/1098773/fbc42d7f-b176-4f3f-94f2-e0420cc376ca)
